### PR TITLE
Remove dependency on `frog`

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,7 +1,7 @@
 #lang info
 (define collection "scribble-frog-helper")
 (define deps '("scribble-lib"
-               "base" "gregor" "timable" "frog" "at-exp-lib"))
+               "base" "gregor" "timable" "at-exp-lib"))
 (define build-deps '("scribble-doc"
                      "scribble-lib" "racket-doc" "rackunit-lib"))
 (define scribblings '(("scribblings/scribble-frog-helper.scrbl" ())))

--- a/main.rkt
+++ b/main.rkt
@@ -99,39 +99,58 @@
            racket/file
            gregor)
 
+  (define command (make-parameter #f))
+  (define post-title (make-parameter #f))
+  (define skip-frog-check? (make-parameter #f))
+  (define make-missing-directories? (make-parameter #f))
+
   (command-line
    #:program (short-program+command-name)
-   #:once-each
+   #:once-any ; only one command at a time
    [("-N" "--new-scribble")
     title
     "your title name of the new post"
-    (or (file-exists? (build-path (current-directory) "frog.rkt"))
-        (file-exists? (build-path (current-directory) "darwin.rkt"))
-        (error "`frog.rkt` or `darwin.rkt` not found, you may want to run `raco frog --init` first."))
-    (define filename @string-append{_src/posts/@|(date->iso8601 (current-date))|-@|title|.scrbl})
-    (define filepath (build-path (current-directory) filename))
-    (and (file-exists? filepath)
-         (error (~a "file already exist: " filepath)))
-    (define filecontent @~a{#lang scribble/manual
+    (command 'new-scribble-post)
+    (post-title title)]
+   #:once-each ; flags
+   [("-f" "--force")
+    "Skip checks that we are in a valid frog or darwin blog"
+    (skip-frog-check? #t)
+    (make-missing-directories? #t)])
 
-                            @"@"(require scribble-frog-helper)
-                            @"@"(require (for-label racket)) @"@"; remove this line if no racket doc links needed
+  (case (command)
+    [(new-scribble-post)
+     (unless (skip-frog-check?)
+       (or (file-exists? (build-path (current-directory) "frog.rkt"))
+           (file-exists? (build-path (current-directory) "darwin.rkt"))
+           (error "`frog.rkt` or `darwin.rkt` not found, you may want to run `raco frog --init` first.")))
+     (define filename @string-append{_src/posts/@|(date->iso8601 (current-date))|-@|(post-title)|.scrbl})
+     (define filepath (build-path (current-directory) filename))
+     (when (make-missing-directories?)
+       (let-values ([(base name must-be-dir?) (split-path filepath)])
+         (make-directory* base)))
+     (and (file-exists? filepath)
+          (error (~a "file already exist: " filepath)))
+     (define filecontent @~a{#lang scribble/manual
 
-                            @"@"title{@title}
-                            @"@"date{@(datetime->iso8601 (now))}
-                            @"@"tags{DRAFT tag1 tag2}
+                             @"@"(require scribble-frog-helper)
+                             @"@"(require (for-label racket)) @"@"; remove this line if no racket doc links needed
+
+                             @"@"title{@(post-title)}
+                             @"@"date{@(datetime->iso8601 (now))}
+                             @"@"tags{DRAFT tag1 tag2}
 
 
-                            Replace this with your post text. Add one or more comma-separated
-                            Tags above. The special tag `DRAFT` will prevent the post from being
-                            published. And text before the `more` line will appear in the post
-                            index page as well.
+                             Replace this with your post text. Add one or more comma-separated
+                             Tags above. The special tag `DRAFT` will prevent the post from being
+                             published. And text before the `more` line will appear in the post
+                             index page as well.
 
-                            <!-- more -->
+                             <!-- more -->
 
-                            @"@"(table-of-contents) @"@"; remove this line if no toc neeeded.
+                             @"@"(table-of-contents) @"@"; remove this line if no toc neeeded.
 
-                            You blog content continues here.
-                            })
-    (display-to-file filecontent filepath)
-    (displayln filepath)]))
+                             You blog content continues here.
+                             })
+     (display-to-file filecontent filepath)
+     (displayln filepath)]))

--- a/main.rkt
+++ b/main.rkt
@@ -99,6 +99,10 @@
            racket/file
            gregor)
 
+  (define (strip-iso8601-nanoseconds str)
+    (define segments (string-split str "."))
+    (car segments))
+
   (define command (make-parameter #f))
   (define post-title (make-parameter #f))
   (define skip-frog-check? (make-parameter #f))
@@ -137,7 +141,7 @@
                              @"@"(require (for-label racket)) @"@"; remove this line if no racket doc links needed
 
                              @"@"title{@(post-title)}
-                             @"@"date{@(datetime->iso8601 (now))}
+                             @"@"date{@(strip-iso8601-nanoseconds (datetime->iso8601 (now)))}
                              @"@"tags{DRAFT tag1 tag2}
 
 

--- a/main.rkt
+++ b/main.rkt
@@ -106,7 +106,8 @@
     title
     "your title name of the new post"
     (or (file-exists? (build-path (current-directory) "frog.rkt"))
-        (error "`frog.rkt` not found, you may want to run `raco frog --init` first."))
+        (file-exists? (build-path (current-directory) "darwin.rkt"))
+        (error "`frog.rkt` or `darwin.rkt` not found, you may want to run `raco frog --init` first."))
     (define filename @string-append{_src/posts/@|(date->iso8601 (current-date))|-@|title|.scrbl})
     (define filepath (build-path (current-directory) filename))
     (and (file-exists? filepath)

--- a/scribblings/scribble-frog-helper.scrbl
+++ b/scribblings/scribble-frog-helper.scrbl
@@ -10,6 +10,16 @@
                         timable/convert
                         timable/gregor)))
 
+@;;; Works like other-doc, except if the module being linked to isn't installed then it links to the
+@;;; public page on docs.racket-lang.org instead.
+@(define (other-doc* mod fallback-url fallback-name)
+   (define (module-exists? path)
+     (with-handlers ([exn:fail:filesystem:missing-module? (λ (e) #f)])
+       (boolean? (module-declared? path))))
+   (if (module-exists? mod)
+       (other-doc mod)
+       (hyperlink fallback-url fallback-name)))
+
 
 @title{scribble-frog-helper}
 @author[(author+email "Yanying Wang" "yanyingwang1@gmail.com")]
@@ -18,7 +28,8 @@
 racket[Scribble] helper functions especially for writing blogs with racket[frog]. Related to:
 @itemlist[
 @item{@other-doc['(lib "scribblings/scribble/scribble.scrbl")]}
-@item{@other-doc['(lib "frog/frog.scrbl")]}
+@item{@other-doc*['(lib "frog/frog.scrbl") "https://docs.racket-lang.org/frog/index.html" "Frog"]}
+@item{@other-doc*['(lib "darwin/darwin.scrbl") "https://docs.racket-lang.org/darwin@darwin/index.html" "Darwin"]}
 ]}
 
 INDEX:
@@ -27,7 +38,11 @@ INDEX:
 @section{raco cmd}
 Install this package first and then run
 @nested[#:style 'inset]{@exec{$ raco frog/helper -N title}}
-to generate a scribble post with all the functions defined by this lib.
+to generate a scribble post with all the functions defined by this lib. This requires the current
+directory to be a valid Frog or Darwin blog.
+
+The optional the @exec{-f}/@exec{--force} flag will force it to proceed regardless of where it is run.
+Doing so will create the @exec{_src/posts/} directory if it does not already exist.
 
 
 


### PR DESCRIPTION
Addresses Issue #2.

- Removed dependency on `frog`
- Modified the check for a `frog.rkt` file to also accept a `darwin.rkt` file
- Added a `-f`/`--force` flag to skip the above check entirely and create `_src/posts` if needed
- Restructured the main submodule to finish parsing the command line before performing an action. This is necessary in order for `-N` and `-f` to be allowed in any order.